### PR TITLE
optimize UnsafeMath#divRoundingUp

### DIFF
--- a/contracts/libraries/SqrtPriceMath.sol
+++ b/contracts/libraries/SqrtPriceMath.sol
@@ -161,6 +161,8 @@ library SqrtPriceMath {
         uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
         uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
 
+        require(sqrtRatioAX96 > 0);
+
         return
             roundUp
                 ? UnsafeMath.divRoundingUp(

--- a/contracts/libraries/UnsafeMath.sol
+++ b/contracts/libraries/UnsafeMath.sol
@@ -5,11 +5,13 @@ pragma solidity >=0.5.0;
 /// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
 library UnsafeMath {
     /// @notice Returns ceil(x / y)
-    /// @dev panics if y == 0, unless x == 0 in which case it returns 0
+    /// @dev division by 0 has unspecified behavior, and must be checked externally
     /// @param x The dividend
     /// @param y The divisor
     /// @return z The quotient, ceil(x / y)
     function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        z = x > 0 ? (x - 1) / y + 1 : 0;
+        assembly {
+            z := add(div(x, y), gt(mod(x, y), 0))
+        }
     }
 }

--- a/contracts/libraries/UnsafeMath.sol
+++ b/contracts/libraries/UnsafeMath.sol
@@ -5,12 +5,11 @@ pragma solidity >=0.5.0;
 /// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
 library UnsafeMath {
     /// @notice Returns ceil(x / y)
-    /// @dev panics if y == 0
+    /// @dev panics if y == 0, unless x == 0 in which case it returns 0
     /// @param x The dividend
     /// @param y The divisor
     /// @return z The quotient, ceil(x / y)
     function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        // addition is safe because (type(uint256).max / 1) + (type(uint256).max % 1 > 0 ? 1 : 0) == type(uint256).max
-        z = (x / y) + (x % y > 0 ? 1 : 0);
+        z = x > 0 ? (x - 1) / y + 1 : 0;
     }
 }

--- a/test/__snapshots__/SqrtPriceMath.spec.ts.snap
+++ b/test/__snapshots__/SqrtPriceMath.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `657`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `631`;
 
 exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `452`;
 
 exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `452`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `657`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `631`;
 
 exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = false gas 1`] = `536`;
 
@@ -14,4 +14,4 @@ exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = true gas 1`] = `7
 
 exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = false gas 1`] = `848`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `514`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `488`;

--- a/test/__snapshots__/SqrtPriceMath.spec.ts.snap
+++ b/test/__snapshots__/SqrtPriceMath.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `584`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `610`;
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `452`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `478`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `452`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `478`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `584`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `610`;
 
 exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = false gas 1`] = `536`;
 

--- a/test/__snapshots__/SqrtPriceMath.spec.ts.snap
+++ b/test/__snapshots__/SqrtPriceMath.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `631`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `584`;
 
 exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `452`;
 
 exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `452`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `631`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `584`;
 
 exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = false gas 1`] = `536`;
 
@@ -14,4 +14,4 @@ exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = true gas 1`] = `7
 
 exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = false gas 1`] = `848`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `488`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `441`;

--- a/test/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/__snapshots__/SwapMath.spec.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact in capped 1`] = `2077`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact in capped 1`] = `2103`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact in partial 1`] = `2776`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact in partial 1`] = `2802`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = `1829`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = `1855`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `2776`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `2802`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2078`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2104`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3054`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3106`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1830`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1856`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3054`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3106`;

--- a/test/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/__snapshots__/SwapMath.spec.ts.snap
@@ -8,10 +8,10 @@ exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = 
 
 exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `2776`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2151`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2125`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3200`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3148`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1903`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1877`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3200`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3148`;

--- a/test/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/__snapshots__/SwapMath.spec.ts.snap
@@ -8,10 +8,10 @@ exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = 
 
 exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `2776`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2125`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2078`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3148`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3054`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1877`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1830`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3148`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3054`;

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPool gas 1`] = `4507873`;
+exports[`UniswapV3Factory #createPool gas 1`] = `4510482`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `24307`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `24320`;
 
-exports[`UniswapV3Factory pool bytecode size 1`] = `21884`;
+exports[`UniswapV3Factory pool bytecode size 1`] = `21897`;

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPool gas 1`] = `4515505`;
+exports[`UniswapV3Factory #createPool gas 1`] = `4513482`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `24345`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `24335`;
 
-exports[`UniswapV3Factory pool bytecode size 1`] = `21922`;
+exports[`UniswapV3Factory pool bytecode size 1`] = `21912`;

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPool gas 1`] = `4513482`;
+exports[`UniswapV3Factory #createPool gas 1`] = `4507873`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `24335`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `24307`;
 
-exports[`UniswapV3Factory pool bytecode size 1`] = `21912`;
+exports[`UniswapV3Factory pool bytecode size 1`] = `21884`;

--- a/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
@@ -30,53 +30,53 @@ exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext 
 
 exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108058`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108023`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108058`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108023`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176440`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176405`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123058`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123023`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159757`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159722`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148949`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148914`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308572`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308537`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163949`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163914`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `108629`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `108641`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `108629`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `108641`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `280277`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `280289`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `123629`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `123641`;
 
 exports[`UniswapV3Pool gas tests fee is off #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118385`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118256`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104378`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104296`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120723`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120547`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `136316`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `135999`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130438`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130215`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `151316`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `150999`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `211316`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `210999`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118385`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118256`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104489`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104407`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108357`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108228`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `123929`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `123659`;
 
 exports[`UniswapV3Pool gas tests fee is on #burn above current price burn entire position after some time passes 1`] = `56987`;
 
@@ -108,21 +108,21 @@ exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext g
 
 exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108070`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108023`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108070`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108023`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176452`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176405`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123070`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123023`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159769`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159722`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148961`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148914`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308584`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308537`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163961`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163914`;
 
 exports[`UniswapV3Pool gas tests fee is on #mint below current price add to position after some time passes 1`] = `108641`;
 
@@ -134,24 +134,24 @@ exports[`UniswapV3Pool gas tests fee is on #mint below current price second posi
 
 exports[`UniswapV3Pool gas tests fee is on #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124584`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124443`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110430`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110336`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `127069`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126881`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `143103`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `142774`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `136931`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `136696`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `158103`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `157774`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `218103`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `217774`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124584`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124443`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110541`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110447`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114556`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114415`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130569`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130287`;

--- a/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
@@ -30,53 +30,53 @@ exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext 
 
 exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108096`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108058`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108096`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108058`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176478`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176440`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123096`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123058`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159795`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159757`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148987`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148949`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308610`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308572`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163987`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163949`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `108641`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `108629`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `108641`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `108629`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `280289`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `280277`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `123641`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `123629`;
 
 exports[`UniswapV3Pool gas tests fee is off #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118475`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118385`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104442`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104378`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120839`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120723`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `136510`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `136316`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130580`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130438`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `151510`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `151316`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `211510`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `211316`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118475`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118385`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104553`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104489`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108447`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108357`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `124097`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `123929`;
 
 exports[`UniswapV3Pool gas tests fee is on #burn above current price burn entire position after some time passes 1`] = `56987`;
 
@@ -108,21 +108,21 @@ exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext g
 
 exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108096`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108070`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108096`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108070`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176478`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176452`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123096`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123070`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159795`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159769`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148987`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148961`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308610`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308584`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163987`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163961`;
 
 exports[`UniswapV3Pool gas tests fee is on #mint below current price add to position after some time passes 1`] = `108641`;
 
@@ -134,24 +134,24 @@ exports[`UniswapV3Pool gas tests fee is on #mint below current price second posi
 
 exports[`UniswapV3Pool gas tests fee is on #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124662`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124584`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110482`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110430`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `127173`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `127069`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `143285`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `143103`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `137061`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `136931`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `158285`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `158103`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `218285`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `218103`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124662`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124584`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110593`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110541`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114634`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114556`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130725`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130569`;

--- a/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Pool gas tests fee is off #burn above current price burn entire position after some time passes 1`] = `56987`;
+exports[`UniswapV3Pool gas tests fee is off #burn above current price burn entire position after some time passes 1`] = `57000`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn above current price burn when only position using ticks 1`] = `56987`;
+exports[`UniswapV3Pool gas tests fee is off #burn above current price burn when only position using ticks 1`] = `57000`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `77279`;
+exports[`UniswapV3Pool gas tests fee is off #burn above current price entire position burn but other positions are using the ticks 1`] = `77305`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn above current price partial position burn 1`] = `92279`;
+exports[`UniswapV3Pool gas tests fee is off #burn above current price partial position burn 1`] = `92305`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn around current price burn entire position after some time passes 1`] = `75499`;
+exports[`UniswapV3Pool gas tests fee is off #burn around current price burn entire position after some time passes 1`] = `75512`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn around current price burn when only position using ticks 1`] = `72195`;
+exports[`UniswapV3Pool gas tests fee is off #burn around current price burn when only position using ticks 1`] = `72208`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `88892`;
+exports[`UniswapV3Pool gas tests fee is off #burn around current price entire position burn but other positions are using the ticks 1`] = `88918`;
 
-exports[`UniswapV3Pool gas tests fee is off #burn around current price partial position burn 1`] = `103892`;
+exports[`UniswapV3Pool gas tests fee is off #burn around current price partial position burn 1`] = `103918`;
 
 exports[`UniswapV3Pool gas tests fee is off #burn below current price burn entire position after some time passes 1`] = `69823`;
 
@@ -30,21 +30,21 @@ exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext 
 
 exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108023`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `108049`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108023`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `108049`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176405`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `176431`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123023`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `123049`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159722`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `159748`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148914`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `148940`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308537`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `308563`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163914`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `163940`;
 
 exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `108641`;
 
@@ -56,43 +56,43 @@ exports[`UniswapV3Pool gas tests fee is off #mint below current price second pos
 
 exports[`UniswapV3Pool gas tests fee is off #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118256`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `118334`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104296`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `104348`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120547`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `120651`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `135999`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `136181`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130215`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `130345`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `150999`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `151181`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `210999`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `211181`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118256`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `118334`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104407`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `104459`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108228`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `108306`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `123659`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `123815`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn above current price burn entire position after some time passes 1`] = `56987`;
+exports[`UniswapV3Pool gas tests fee is on #burn above current price burn entire position after some time passes 1`] = `57000`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn above current price burn when only position using ticks 1`] = `56987`;
+exports[`UniswapV3Pool gas tests fee is on #burn above current price burn when only position using ticks 1`] = `57000`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `77279`;
+exports[`UniswapV3Pool gas tests fee is on #burn above current price entire position burn but other positions are using the ticks 1`] = `77305`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn above current price partial position burn 1`] = `92279`;
+exports[`UniswapV3Pool gas tests fee is on #burn above current price partial position burn 1`] = `92305`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn around current price burn entire position after some time passes 1`] = `75499`;
+exports[`UniswapV3Pool gas tests fee is on #burn around current price burn entire position after some time passes 1`] = `75512`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn around current price burn when only position using ticks 1`] = `72195`;
+exports[`UniswapV3Pool gas tests fee is on #burn around current price burn when only position using ticks 1`] = `72208`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `88892`;
+exports[`UniswapV3Pool gas tests fee is on #burn around current price entire position burn but other positions are using the ticks 1`] = `88918`;
 
-exports[`UniswapV3Pool gas tests fee is on #burn around current price partial position burn 1`] = `103892`;
+exports[`UniswapV3Pool gas tests fee is on #burn around current price partial position burn 1`] = `103918`;
 
 exports[`UniswapV3Pool gas tests fee is on #burn below current price burn entire position after some time passes 1`] = `69823`;
 
@@ -108,21 +108,21 @@ exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext g
 
 exports[`UniswapV3Pool gas tests fee is on #increaseObservationCardinalityNext no op 1`] = `28277`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108023`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position after some time passes 1`] = `108049`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108023`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price add to position existing 1`] = `108049`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176405`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price new position mint first in range 1`] = `176431`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123023`;
+exports[`UniswapV3Pool gas tests fee is on #mint above current price second position in same range 1`] = `123049`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159722`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position after some time passes 1`] = `159748`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148914`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price add to position existing 1`] = `148940`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308537`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price new position mint first in range 1`] = `308563`;
 
-exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163914`;
+exports[`UniswapV3Pool gas tests fee is on #mint around current price second position in same range 1`] = `163940`;
 
 exports[`UniswapV3Pool gas tests fee is on #mint below current price add to position after some time passes 1`] = `108641`;
 
@@ -134,24 +134,24 @@ exports[`UniswapV3Pool gas tests fee is on #mint below current price second posi
 
 exports[`UniswapV3Pool gas tests fee is on #poke best case 1`] = `42584`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124443`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `124521`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110336`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `110388`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126881`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126985`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `142774`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `142956`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `136696`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `136826`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `157774`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes (seconds outside is set) 1`] = `157956`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `217774`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `217956`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124443`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `124521`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110447`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `110499`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114415`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `114493`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130287`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `130443`;


### PR DESCRIPTION
fixes https://github.com/Uniswap/uniswap-v3-core/issues/445

this function is only 'unsafe' in the case where `y == 0` (see echidna test, mythx analysis)

this function is called in 3 places:
- [SqrtPriceMath#getNextSqrtPriceFromAmount0RoundingUp](https://github.com/Uniswap/uniswap-v3-core/blob/864efb5bb57bd8bde4689cfd8f7fd7ddeb100524/contracts/libraries/SqrtPriceMath.sol#L47)
- - we know this is safe, because `amount != 0` per the check at the beginning of the function, so the denominator is always non-zero
- [SqrtPriceMath#getNextSqrtPriceFromAmount1RoundingDown](https://github.com/Uniswap/uniswap-v3-core/blob/864efb5bb57bd8bde4689cfd8f7fd7ddeb100524/contracts/libraries/SqrtPriceMath.sol#L89)
- - this is safe only if `liquidity != 0`
- - this method is called in two places [1](https://github.com/Uniswap/uniswap-v3-core/blob/864efb5bb57bd8bde4689cfd8f7fd7ddeb100524/contracts/libraries/SqrtPriceMath.sol#L119) [2](https://github.com/Uniswap/uniswap-v3-core/blob/864efb5bb57bd8bde4689cfd8f7fd7ddeb100524/contracts/libraries/SqrtPriceMath.sol#L141) which both require `liquidity > 0`
- [SqrtPriceMath#getAmount0Delta](https://github.com/Uniswap/uniswap-v3-core/blob/864efb5bb57bd8bde4689cfd8f7fd7ddeb100524/contracts/libraries/SqrtPriceMath.sol#L166-L169)
- - this is safe only if the `sqrtRatioAX96 != 0`
- - ratios are expected to be non-zero everywhere this function is called, per the echidna test: https://github.com/Uniswap/uniswap-v3-core/blob/006442da5112f8e6c380356e800f638639ec1552/contracts/test/SqrtPriceMathEchidnaTest.sol#L108
- - added a require anyway https://github.com/Uniswap/uniswap-v3-core/pull/446/commits/a8e6a24cdbaa32a4e4ca52fd00f76d5342b241f3