### PR TITLE
make the oracle fuzz test stricter

### DIFF
--- a/contracts/test/OracleEchidnaTest.sol
+++ b/contracts/test/OracleEchidnaTest.sol
@@ -92,15 +92,15 @@ contract OracleEchidnaTest {
 
     function checkTwoAdjacentObservationsModTimeElapsedAlways0(uint16 index) external view {
         uint16 cardinality = oracle.cardinality();
-        require(index < cardinality && index != (oracle.index() + 1) % cardinality);
+        require(index < cardinality && cardinality > 1);
 
         (uint32 blockTimestamp0, int56 tickCumulative0, uint160 liquidityCumulative0, bool initialized0) =
             oracle.observations(index == 0 ? cardinality - 1 : index - 1);
         (uint32 blockTimestamp1, int56 tickCumulative1, uint160 liquidityCumulative1, bool initialized1) =
             oracle.observations(index);
 
-        require(initialized0);
-        require(initialized1);
+        assert(initialized0);
+        assert(initialized1);
 
         uint32 timeElapsed = blockTimestamp1 - blockTimestamp0;
         assert(timeElapsed > 0);

--- a/contracts/test/OracleEchidnaTest.sol
+++ b/contracts/test/OracleEchidnaTest.sol
@@ -99,8 +99,8 @@ contract OracleEchidnaTest {
         (uint32 blockTimestamp1, int56 tickCumulative1, uint160 liquidityCumulative1, bool initialized1) =
             oracle.observations(index);
 
-        assert(initialized0);
-        assert(initialized1);
+        require(initialized0);
+        require(initialized1);
 
         uint32 timeElapsed = blockTimestamp1 - blockTimestamp0;
         assert(timeElapsed > 0);


### PR DESCRIPTION
the check is actually saying the index is not the oldest observation