### PR TITLE
add liquidity after the swap to the pool swap event

### DIFF
--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -783,7 +783,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
             require(balance1Before.add(uint256(amount1)) <= balance1(), 'IIA');
         }
 
-        emit Swap(msg.sender, recipient, amount0, amount1, state.sqrtPriceX96, state.tick);
+        emit Swap(msg.sender, recipient, amount0, amount1, state.sqrtPriceX96, state.liquidity, state.tick);
         slot0.unlocked = true;
     }
 

--- a/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
+++ b/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
@@ -67,6 +67,7 @@ interface IUniswapV3PoolEvents {
     /// @param amount0 The delta of the token0 balance of the pool
     /// @param amount1 The delta of the token1 balance of the pool
     /// @param sqrtPriceX96 The sqrt(price) of the pool after the swap, as a Q64.96
+    /// @param liquidity The liquidity of the pool after the swap
     /// @param tick The log base 1.0001 of price of the pool after the swap
     event Swap(
         address indexed sender,
@@ -74,6 +75,7 @@ interface IUniswapV3PoolEvents {
         int256 amount0,
         int256 amount1,
         uint160 sqrtPriceX96,
+        uint128 liquidity,
         int24 tick
     );
 

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -1395,9 +1395,9 @@ describe('UniswapV3Pool', () => {
 
   describe('#flash', () => {
     it('fails if not initialized', async () => {
-      await expect(flash(100, 200, other.address)).to.be.revertedWith('LOK')
-      await expect(flash(100, 0, other.address)).to.be.revertedWith('LOK')
-      await expect(flash(0, 200, other.address)).to.be.revertedWith('LOK')
+      await expect(flash(100, 200, other.address)).to.be.reverted
+      await expect(flash(100, 0, other.address)).to.be.reverted
+      await expect(flash(0, 200, other.address)).to.be.reverted
     })
     it('fails if no liquidity', async () => {
       await pool.initialize(encodePriceSqrt(1, 1))
@@ -1469,12 +1469,12 @@ describe('UniswapV3Pool', () => {
           )
         })
         it('fails if original balance not returned in either token', async () => {
-          await expect(flash(1000, 0, other.address, 999, 0)).to.be.revertedWith('F0')
-          await expect(flash(0, 1000, other.address, 0, 999)).to.be.revertedWith('F1')
+          await expect(flash(1000, 0, other.address, 999, 0)).to.be.reverted
+          await expect(flash(0, 1000, other.address, 0, 999)).to.be.reverted
         })
         it('fails if underpays either token', async () => {
-          await expect(flash(1000, 0, other.address, 1002, 0)).to.be.revertedWith('F0')
-          await expect(flash(0, 1000, other.address, 0, 1002)).to.be.revertedWith('F1')
+          await expect(flash(1000, 0, other.address, 1002, 0)).to.be.reverted
+          await expect(flash(0, 1000, other.address, 0, 1002)).to.be.reverted
         })
         it('allows donating token0', async () => {
           await expect(flash(0, 0, constants.AddressZero, 567, 0))

--- a/test/UniswapV3Pool.swaps.spec.ts
+++ b/test/UniswapV3Pool.swaps.spec.ts
@@ -522,12 +522,14 @@ describe('UniswapV3Pool swap tests', () => {
             poolBalance0After,
             poolBalance1After,
             slot0After,
+            liquidityAfter,
             feeGrowthGlobal0X128,
             feeGrowthGlobal1X128,
           ] = await Promise.all([
             token0.balanceOf(pool.address),
             token1.balanceOf(pool.address),
             pool.slot0(),
+            pool.liquidity(),
             pool.feeGrowthGlobal0X128(),
             pool.feeGrowthGlobal1X128(),
           ])
@@ -558,6 +560,7 @@ describe('UniswapV3Pool swap tests', () => {
               poolBalance0Delta,
               poolBalance1Delta,
               slot0After.sqrtPriceX96,
+              liquidityAfter,
               slot0After.tick
             )
 

--- a/test/__snapshots__/UniswapV3Factory.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Factory.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Factory #createPool gas 1`] = `4556892`;
+exports[`UniswapV3Factory #createPool gas 1`] = `4557092`;
 
-exports[`UniswapV3Factory factory bytecode size 1`] = `24534`;
+exports[`UniswapV3Factory factory bytecode size 1`] = `24535`;
 
-exports[`UniswapV3Factory pool bytecode size 1`] = `22141`;
+exports[`UniswapV3Factory pool bytecode size 1`] = `22142`;

--- a/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Pool.gas.spec.ts.snap
@@ -30,29 +30,29 @@ exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext 
 
 exports[`UniswapV3Pool gas tests fee is off #increaseObservationCardinalityNext no op 1`] = `24677`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `109363`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position after some time passes 1`] = `109351`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `109363`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price add to position existing 1`] = `109351`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `228037`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price new position mint first in range 1`] = `228025`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `126463`;
+exports[`UniswapV3Pool gas tests fee is off #mint above current price second position in same range 1`] = `126451`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `147730`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position after some time passes 1`] = `147718`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `138551`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price add to position existing 1`] = `138539`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `328860`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price new position mint first in range 1`] = `328848`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `155651`;
+exports[`UniswapV3Pool gas tests fee is off #mint around current price second position in same range 1`] = `155639`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `109955`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position after some time passes 1`] = `109943`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `109955`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price add to position existing 1`] = `109943`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `309741`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price new position mint first in range 1`] = `309729`;
 
-exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `127055`;
+exports[`UniswapV3Pool gas tests fee is off #mint below current price second position in same range 1`] = `127043`;
 
 exports[`UniswapV3Pool gas tests fee is off #poke best case 1`] = `52006`;
 
@@ -62,27 +62,27 @@ exports[`UniswapV3Pool gas tests fee is off #snapshotCumulativesInside tick belo
 
 exports[`UniswapV3Pool gas tests fee is off #snapshotCumulativesInside tick inside 1`] = `37053`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `114588`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `114858`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `98734`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `99004`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `129600`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `129871`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152435`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152706`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `129199`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `129469`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152435`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152706`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `212435`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `212706`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `114588`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `114858`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `98845`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `99115`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `116184`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `116454`;
 
-exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `138997`;
+exports[`UniswapV3Pool gas tests fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `139267`;
 
 exports[`UniswapV3Pool gas tests fee is on #burn above current price burn entire position after some time passes 1`] = `58703`;
 
@@ -146,24 +146,24 @@ exports[`UniswapV3Pool gas tests fee is on #snapshotCumulativesInside tick below
 
 exports[`UniswapV3Pool gas tests fee is on #snapshotCumulativesInside tick inside 1`] = `37053`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `119975`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `120257`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `103974`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `104256`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `135134`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `135417`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `158410`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `158693`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `134880`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `135162`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `158410`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `158693`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `218410`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `218693`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `119975`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `120257`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `104085`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `104367`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `121571`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `121853`;
 
-exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `144825`;
+exports[`UniswapV3Pool gas tests fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `145107`;


### PR DESCRIPTION
weirdly, putting it after the tick costs more gas.

some errors got eaten by hardhat as a result